### PR TITLE
Fixes railtie that includes controller helper

### DIFF
--- a/lib/ultimate_turbo_modal/railtie.rb
+++ b/lib/ultimate_turbo_modal/railtie.rb
@@ -9,7 +9,7 @@ require "ultimate_turbo_modal/helpers/stream_helper"
 module UltimateTurboModal
   class Railtie < Rails::Railtie
     initializer "ultimate_turbo_modal.action_controller" do
-      ActiveSupport.on_load(:action_controller) do
+      ActiveSupport.on_load(:action_controller_base) do
         include UltimateTurboModal::Helpers::ControllerHelper
       end
     end


### PR DESCRIPTION
Fixes #9

Example documentation for `ActiveSupport.on_load` here: https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html

gives an example of using `action_controller_base` for the hook, instead of just `action_controller`.

This seems to solve my problem from the linked issue. For some reason loading based on just `action_controller` is trying to include the module on top of `ActionController::API`, which doesn't have the `helper_method` method, changing it as I have done in this PR makes it work as expected.