### PR TITLE
Fix Phlex deprecation warning

### DIFF
--- a/lib/phlex/deferred_render_with_main_content.rb
+++ b/lib/phlex/deferred_render_with_main_content.rb
@@ -2,7 +2,7 @@
 
 module Phlex
   module DeferredRenderWithMainContent
-    def template(&block)
+    def view_template(&block)
       output = capture(&block)
       super { unsafe_raw(output) }
     end

--- a/lib/ultimate_turbo_modal/base.rb
+++ b/lib/ultimate_turbo_modal/base.rb
@@ -49,7 +49,7 @@ class UltimateTurboModal::Base < Phlex::HTML
     end
   end
 
-  def template(&block)
+  def view_template(&block)
     if turbo_frame?
       turbo_frame_tag("modal") do
         modal(&block)


### PR DESCRIPTION
I think I'd probably prefer to see this library not using phlex at all, but to at least stop the deprecation warning, this should do, and seems to still function properly.

Fixes #11 