### PR TITLE
Improve inside_modal?

### DIFF
--- a/lib/ultimate_turbo_modal/helpers/controller_helper.rb
+++ b/lib/ultimate_turbo_modal/helpers/controller_helper.rb
@@ -4,8 +4,9 @@ module UltimateTurboModal::Helpers
   module ControllerHelper
     extend ActiveSupport::Concern
 
-    def inside_modal?
-      request.headers["Turbo-Frame"] == "modal"
+     def inside_modal?
+      turbo_frame = request.headers["Turbo-Frame"]
+      turbo_frame.present? && turbo_frame.start_with?("modal")
     end
 
     included do


### PR DESCRIPTION
Also detect "modal-inner"  as being inside a modal context.

This allows deep nesting of multiple modal links.