### PR TITLE
Add modal-from-drawer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- Added support for opening a modal from inside a drawer. Any link inside a drawer with `data-turbo-frame="drawer-modal"` will now open a modal stacked on top of the drawer. ESC, click-outside, and form submissions handle the stacked case correctly. See [docs/modal-from-drawer.md](docs/modal-from-drawer.md).
+
 ## [3.0.5] - 2026-04-22
 
 - Fixed modal being dismissed when a body-appended widget (e.g. flatpickr, Select2, Tippy) opens over its trigger between mousedown and mouseup. The browser fires `click` on the dialog (common ancestor), which was treated as a backdrop dismissal. The dialog now tracks mousedown origin and skips dismissal when the press started inside content.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,49 @@ Link to it the same way as a modal:
 | CSS string | Custom value, e.g. `"500px"` or `"50vw"` |
 
 
+## Opening a Modal from a Drawer
+
+You can open a regular modal that stacks on top of an open drawer. This is built in — no setup or opt-in required.
+
+Inside any drawer, link to a modal action with `data-turbo-frame="drawer-modal"`:
+
+```erb
+<%= drawer(title: "Notifications") do %>
+  <p>Activity list here…</p>
+  <%= link_to "Edit preferences",
+        edit_preferences_path,
+        data: { turbo_frame: "drawer-modal" } %>
+<% end %>
+```
+
+The destination is rendered with the same `modal()` helper you use elsewhere:
+
+```erb
+<%= modal(title: "Notification preferences") do %>
+  <p>Form here…</p>
+<% end %>
+```
+
+The gem detects the request and renders the modal into a stacked `<dialog>` that sits visually on top of the drawer.
+
+### Behavior
+
+- **ESC** closes the modal first, then the drawer (native top-layer behavior).
+- **Click outside** the modal closes the modal only; the drawer stays open.
+- **`turbo_stream.modal(:close)`** closes the topmost dialog (the modal).
+- **Form submission with same-page redirect** closes the modal smoothly; the drawer stays.
+- **Form submission with a different-page redirect** closes both dialogs, then navigates.
+- **Closing the drawer** (via close button, ESC after the modal closes, etc.) also tears down any modal opened from it.
+
+### Constraints
+
+- Modal-from-drawer only. You cannot open a drawer from inside a modal, and you cannot stack a modal on top of another modal. The `drawer-modal` frame is only rendered inside drawers.
+- Stacked modals always force `advance: false` (history is not pushed). All other modal options (overlay, padding, header, footer, etc.) work normally.
+- Both backdrops are drawn when both dialogs have `overlay: true`. Pass `overlay: false` to the inner modal if you don't want the drawer to look slightly darker while the modal is open.
+
+For a full lifecycle walkthrough and edge-case notes, see [docs/modal-from-drawer.md](docs/modal-from-drawer.md).
+
+
 ## Features and capabilities
 
 - Extremely easy to use

--- a/demo-app/app/controllers/showcase_controller.rb
+++ b/demo-app/app/controllers/showcase_controller.rb
@@ -5,10 +5,15 @@ class ShowcaseController < ApplicationController
   end
 
   def show
+    @contact = Contact.new
   end
 
   def save_project
     redirect_to root_path, notice: "Project saved successfully!"
+  end
+
+  def save_preferences
+    redirect_to root_path, notice: "Notification preferences saved!"
   end
 
   def submit
@@ -26,7 +31,24 @@ class ShowcaseController < ApplicationController
     end
   end
 
+  def submit_contact
+    @contact = Contact.new(contact_params)
+
+    if @contact.valid?
+      redirect_to root_path,
+        notice: "Message sent successfully!",
+        status: :see_other
+    else
+      params[:id] = "form_modal"
+      render :show, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def contact_params
+    params.require(:contact).permit(:name, :email, :message)
+  end
 
   def form_is_valid?
     action_name == "show" || params[:email].present?

--- a/demo-app/app/controllers/testing/drawers_controller.rb
+++ b/demo-app/app/controllers/testing/drawers_controller.rb
@@ -4,4 +4,20 @@ class Testing::DrawersController < ApplicationController
 
   def show
   end
+
+  def nested_modal
+    # Renders the modal that opens inside the drawer.
+    render :nested_modal
+  end
+
+  def nested_modal_same_page
+    # Redirects back to the page the drawer was opened from (the testing
+    # drawers index). With my drawer still open, this triggers the smooth
+    # same-page-with-sibling path: only the inner modal closes.
+    redirect_to testing_drawers_path
+  end
+
+  def nested_modal_other_page
+    redirect_to testing_modal_index_path
+  end
 end

--- a/demo-app/app/models/contact.rb
+++ b/demo-app/app/models/contact.rb
@@ -1,0 +1,9 @@
+class Contact
+  include ActiveModel::Model
+
+  attr_accessor :name, :email, :message
+
+  validates :name, presence: true
+  validates :email, presence: true
+  validates :message, presence: true
+end

--- a/demo-app/app/views/showcase/index.html.erb
+++ b/demo-app/app/views/showcase/index.html.erb
@@ -95,6 +95,14 @@
         <h3 class="font-semibold text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">Colored Header</h3>
         <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Form drawer with colored header and footer buttons.</p>
       <% end %>
+
+      <%# Drawer with nested modal %>
+      <%= link_to showcase_path(:drawer_with_nested_modal), data: { turbo_frame: "modal" },
+          class: "group relative rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-lg hover:shadow-indigo-500/10 transition-all" do %>
+        <div class="text-2xl mb-3">🪆</div>
+        <h3 class="font-semibold text-slate-900 dark:text-white group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">Modal from Drawer</h3>
+        <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">Open a modal stacked on top of an open drawer.</p>
+      <% end %>
     </div>
   </div>
 </section>

--- a/demo-app/app/views/showcase/show.html.erb
+++ b/demo-app/app/views/showcase/show.html.erb
@@ -10,24 +10,34 @@
 
 <% when "form_modal" %>
   <%= modal(title: "Contact Us") do %>
-    <form class="space-y-4">
+    <%= form_with model: @contact, url: showcase_submit_contact_path, class: "space-y-4 w-96 max-w-full" do |form| %>
+      <% if @contact.errors.any? %>
+        <div class="bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400 px-3 py-2 rounded-lg">
+          <h2 class="font-medium"><%= pluralize(@contact.errors.count, "error") %> prohibited this message from being sent:</h2>
+          <ul class="list-disc list-inside text-sm mt-1">
+            <% @contact.errors.each do |error| %>
+              <li><%= error.full_message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
       <div>
-        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="name">Name</label>
-        <input type="text" id="name" name="name" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" placeholder="Jane Doe">
+        <%= form.label :name, class: "block text-sm font-medium text-slate-700 dark:text-slate-300" %>
+        <%= form.text_field :name, placeholder: "Jane Doe", class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" %>
       </div>
       <div>
-        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="email">Email</label>
-        <input type="email" id="email" name="email" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" placeholder="jane@example.com">
+        <%= form.label :email, class: "block text-sm font-medium text-slate-700 dark:text-slate-300" %>
+        <%= form.email_field :email, placeholder: "jane@example.com", class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" %>
       </div>
       <div>
-        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300" for="message">Message</label>
-        <textarea id="message" name="message" rows="3" class="mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" placeholder="Your message..."></textarea>
+        <%= form.label :message, class: "block text-sm font-medium text-slate-700 dark:text-slate-300" %>
+        <%= form.text_area :message, rows: 3, placeholder: "Your message...", class: "mt-1 block w-full rounded-md border-slate-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-slate-700 dark:border-slate-600 dark:text-white" %>
       </div>
       <div class="flex justify-end gap-3 pt-2">
         <button type="button" data-action="modal#hideModal" class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 hover:bg-slate-50 dark:bg-slate-700 dark:text-white dark:ring-slate-600 dark:hover:bg-slate-600">Cancel</button>
-        <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">Send</button>
+        <%= form.submit "Send", class: "rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 cursor-pointer" %>
       </div>
-    </form>
+    <% end %>
   <% end %>
 
 <% when "long_modal" %>
@@ -218,6 +228,66 @@
       <div class="flex shrink-0 justify-end w-full">
         <button type="button" data-action="modal#hideModal" class="rounded-md bg-white dark:bg-white/10 px-3 py-2 text-sm font-semibold text-gray-900 dark:text-gray-100 shadow-xs inset-ring inset-ring-gray-300 dark:inset-ring-white/5 hover:bg-gray-50 dark:hover:bg-white/20">Cancel</button>
         <button type="submit" form="project-form" class="ml-4 inline-flex justify-center rounded-md bg-indigo-600 dark:bg-indigo-500 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 dark:hover:bg-indigo-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-500">Save</button>
+      </div>
+    <% end %>
+  <% end %>
+
+<% when "drawer_with_nested_modal" %>
+  <%= drawer(title: "Notifications") do %>
+    <div class="space-y-4">
+      <p class="text-sm text-slate-600 dark:text-slate-400">
+        Recent activity. Click <em>Edit preferences</em> to open a modal that
+        stacks <strong>on top</strong> of this drawer.
+      </p>
+
+      <% 4.times do |i| %>
+        <div class="flex gap-3 p-3 rounded-lg bg-slate-50 dark:bg-slate-700/50">
+          <div class="flex-shrink-0 w-8 h-8 rounded-full bg-indigo-100 dark:bg-indigo-900/50 flex items-center justify-center text-indigo-600 dark:text-indigo-400 text-sm font-medium"><%= (65 + i).chr %></div>
+          <div>
+            <p class="text-sm font-medium text-slate-900 dark:text-white"><%= Faker::Name.name %></p>
+            <p class="text-sm text-slate-500 dark:text-slate-400"><%= Faker::Lorem.sentence(word_count: 6) %></p>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="pt-2">
+        <%= link_to "Edit preferences →",
+              showcase_path(:nested_modal_form),
+              data: { turbo_frame: "drawer-modal" },
+              class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
+      </div>
+    </div>
+  <% end %>
+
+<% when "nested_modal_form" %>
+  <%= modal(title: "Notification preferences") do |m| %>
+    <%= form_with url: showcase_save_preferences_path, method: :post, html: { id: "preferences-form" }, class: "space-y-4" do |f| %>
+      <p class="text-sm text-slate-600 dark:text-slate-400">
+        This modal opened from inside the drawer. The drawer stays open behind it.
+      </p>
+
+      <div class="space-y-3">
+        <label class="flex items-start gap-3">
+          <input type="checkbox" name="email" checked class="mt-1 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+          <div>
+            <div class="text-sm font-medium text-slate-900 dark:text-white">Email notifications</div>
+            <div class="text-sm text-slate-500 dark:text-slate-400">Get a digest once a day.</div>
+          </div>
+        </label>
+        <label class="flex items-start gap-3">
+          <input type="checkbox" name="push" class="mt-1 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+          <div>
+            <div class="text-sm font-medium text-slate-900 dark:text-white">Push notifications</div>
+            <div class="text-sm text-slate-500 dark:text-slate-400">Real-time alerts on your phone.</div>
+          </div>
+        </label>
+      </div>
+    <% end %>
+
+    <% m.footer do %>
+      <div class="flex justify-end gap-3 w-full">
+        <button type="button" data-action="modal#hideModal" class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-slate-900 shadow-sm ring-1 ring-inset ring-slate-300 hover:bg-slate-50 dark:bg-slate-700 dark:text-white dark:ring-slate-600 dark:hover:bg-slate-600">Cancel</button>
+        <button type="submit" form="preferences-form" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">Save preferences</button>
       </div>
     <% end %>
   <% end %>

--- a/demo-app/app/views/testing/drawers/index.html.erb
+++ b/demo-app/app/views/testing/drawers/index.html.erb
@@ -10,6 +10,7 @@
         <li class="py-2"><%= link_to "Drawer with header divider", testing_drawer_path(:header_divider), data: {turbo_frame: "modal"} %>
         <li class="py-2"><%= link_to "Drawer with long content", testing_drawer_path(:long), data: {turbo_frame: "modal"} %>
         <li class="py-2"><%= link_to "Drawer with footer", testing_drawer_path(:footer), data: {turbo_frame: "modal"} %>
+        <li class="py-2"><%= link_to "Drawer hosting a nested modal", testing_drawer_path(:nested_modal_host), data: {turbo_frame: "modal"} %>
       </ul>
     </div>
 

--- a/demo-app/app/views/testing/drawers/nested_modal.html.erb
+++ b/demo-app/app/views/testing/drawers/nested_modal.html.erb
@@ -1,0 +1,45 @@
+<% scenario = params[:scenario] %>
+
+<% if scenario == "long" %>
+  <%= modal(title: "Long nested modal") do |m| %>
+    <div class="space-y-4">
+      <% 12.times do %>
+        <p><%= Faker::Lorem.paragraph(sentence_count: 6) %></p>
+      <% end %>
+    </div>
+    <% m.footer do %>
+      <div class="flex justify-end w-full">
+        <button type="button" data-action="modal#hideModal" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">Close</button>
+      </div>
+    <% end %>
+  <% end %>
+
+<% elsif scenario == "no_overlay" %>
+  <%= modal(title: "Nested modal (no overlay)", overlay: false) do %>
+    <p>This stacked modal disables its own backdrop, so the drawer behind isn't double-darkened.</p>
+    <p class="mt-4">Click outside this modal to dismiss it.</p>
+  <% end %>
+
+<% else %>
+  <%= modal(title: "Nested modal") do |m| %>
+    <div class="space-y-4">
+      <p>I am a modal opened from inside a drawer. The drawer is still open behind me.</p>
+
+      <%= form_with url: nested_modal_same_page_testing_drawers_path, method: :post do %>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Submit to test same-page redirect (modal closes, drawer stays):</p>
+        <button type="submit" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500">Save (same-page redirect)</button>
+      <% end %>
+
+      <%= form_with url: nested_modal_other_page_testing_drawers_path, method: :post do %>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-4">Submit to test different-page redirect (both close, navigate):</p>
+        <button type="submit" class="rounded-md bg-rose-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-rose-500">Save (other-page redirect)</button>
+      <% end %>
+    </div>
+
+    <% m.footer do %>
+      <div class="flex justify-end w-full">
+        <button type="button" data-action="modal#hideModal" class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-700 dark:text-white dark:ring-gray-600 dark:hover:bg-gray-600">Close</button>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/demo-app/app/views/testing/drawers/show.html.erb
+++ b/demo-app/app/views/testing/drawers/show.html.erb
@@ -54,4 +54,37 @@
       </div>
     <% end %>
   <% end %>
+
+<%# Nested modal host — opens stacked modals from inside this drawer %>
+<% elsif params[:id] == "nested_modal_host" %>
+  <%= drawer(title: "Drawer (host)") do %>
+    <div class="space-y-4">
+      <p>This drawer hosts links that open a modal on top.</p>
+
+      <ul class="list-disc ml-6 space-y-2">
+        <li>
+          <%= link_to "Open nested modal (basic)",
+                nested_modal_testing_drawers_path,
+                data: { turbo_frame: "drawer-modal" } %>
+        </li>
+        <li>
+          <%= link_to "Open nested modal (long content)",
+                nested_modal_testing_drawers_path(scenario: :long),
+                data: { turbo_frame: "drawer-modal" } %>
+        </li>
+        <li>
+          <%= link_to "Open nested modal (no overlay)",
+                nested_modal_testing_drawers_path(scenario: :no_overlay),
+                data: { turbo_frame: "drawer-modal" } %>
+        </li>
+      </ul>
+
+      <p class="text-sm text-gray-500 dark:text-gray-400 pt-4 border-t mt-4">
+        Test cases: ESC closes inner modal first, then drawer.
+        Click outside inner modal closes inner only.
+        Form redirects to same page → inner closes, drawer stays.
+        Form redirects to different page → both close, page navigates.
+      </p>
+    </div>
+  <% end %>
 <% end %>

--- a/demo-app/config/routes.rb
+++ b/demo-app/config/routes.rb
@@ -2,11 +2,19 @@ Rails.application.routes.draw do
   root to: "showcase#index"
   resources :showcase, only: [:show]
   post "/showcase/submit", to: "showcase#submit", as: :showcase_submit
+  post "/showcase/submit_contact", to: "showcase#submit_contact", as: :showcase_submit_contact
   post "/showcase/save_project", to: "showcase#save_project", as: :showcase_save_project
+  post "/showcase/save_preferences", to: "showcase#save_preferences", as: :showcase_save_preferences
 
   namespace :testing do
     resources :modal
-    resources :drawers
+    resources :drawers do
+      collection do
+        get :nested_modal
+        post :nested_modal_same_page
+        post :nested_modal_other_page
+      end
+    end
     resources :posts
     resource :hide_from_backend, only: [:new, :create]
     resources :smooth_redirects, only: [:new, :create]

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../javascript": {
       "name": "ultimate_turbo_modal",
-      "version": "3.0.4",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@hotwired/turbo-rails": "^8.0.0",

--- a/docs/modal-from-drawer.md
+++ b/docs/modal-from-drawer.md
@@ -1,0 +1,111 @@
+# Opening a Modal from a Drawer
+
+Ultimate Turbo Modal supports opening a regular modal that stacks visually on top of an already-open drawer. This document covers how it works under the hood, what edge cases to expect, and how to test it.
+
+## Quick start
+
+Inside any drawer, link to a modal action with `data-turbo-frame="drawer-modal"`:
+
+```erb
+<%= drawer(title: "Notifications") do %>
+  <%= link_to "Edit preferences",
+        edit_preferences_path,
+        data: { turbo_frame: "drawer-modal" } %>
+<% end %>
+```
+
+The target action renders with the standard `modal()` helper — no special API.
+
+```erb
+<%= modal(title: "Notification preferences") do %>
+  <%= form_with url: preferences_path, method: :post do %>
+    …
+  <% end %>
+<% end %>
+```
+
+That's it. No layout change, no opt-in.
+
+## How it works
+
+Drawers always render an empty `<turbo-frame id="drawer-modal">` inside their DOM, alongside the visible drawer panel. When a link inside the drawer targets that frame, Turbo loads the response into it — and because the response is rendered with `modal()`, it's a `<dialog>` that gets pushed onto the browser's native top layer above the drawer.
+
+Internally:
+
+- The stacked dialog uses a different element id (`modal-container-stacked`) so it doesn't collide with the primary modal/drawer (`modal-container`) for cleanup, scroll-lock, and CSS purposes.
+- Every inner element (`modal-content`, `modal-header`, etc.) is suffixed with `-stacked` for the same reason.
+- A module-level dialog stack tracks every open dialog. `window.modal` is always re-pointed at the topmost one, so existing single-modal code continues to work unchanged.
+
+## Lifecycle
+
+```
+1. Drawer opens (turbo-frame#modal)
+   ├─ <dialog id="modal-container">
+   └─ contains an empty <turbo-frame id="drawer-modal">
+
+2. Link inside drawer with data-turbo-frame="drawer-modal" is clicked
+   ├─ Turbo loads response into the empty frame
+   └─ Response is rendered by modal() with stacked ids
+
+3. Stacked modal connects
+   ├─ <dialog id="modal-container-stacked"> appears on top of drawer
+   ├─ window.modal points to the stacked modal
+   └─ Drawer's controller is still in dialogStack
+
+4. User dismisses stacked modal (ESC, close button, click-outside, server)
+   ├─ Inner closes with animation
+   ├─ window.modal reverts to drawer's controller
+   └─ Drawer remains visible
+
+5. User dismisses drawer
+   └─ Standard drawer close path
+```
+
+## Edge cases
+
+### ESC key
+
+Native `<dialog>` elements form a top-layer stack. Pressing ESC dispatches the `cancel` event to the topmost dialog only. So one ESC closes the inner modal; another ESC closes the drawer.
+
+### Click outside
+
+Each dialog's controller checks whether the click was inside its own content card. The inner modal's content is its modal card, so a click anywhere outside that card (including on the visible drawer behind) is treated as an outside-click and closes the inner modal.
+
+### Form submission inside the inner modal
+
+Two redirect cases:
+
+- **Same-page redirect** (the form action redirects back to the page the drawer was opened from): the inner modal closes smoothly with its animation, the URL is updated via `history.replaceState`, and the drawer stays open. The page body is *not* morphed — that would clobber the drawer's DOM.
+- **Different-page redirect**: every open dialog (the inner modal and the drawer) is closed in sequence, top-down, then `Turbo.visit()` navigates to the new page.
+
+If the form returns a Turbo Stream response, it's processed normally. `turbo_stream.modal(:close)` operates on `window.modal`, which is the inner modal.
+
+### Closing the drawer while the modal is open
+
+If the drawer is closed (e.g. from a Turbo Stream or a programmatic call) while the inner modal is still open, the modal disappears with the drawer. There is no graceful animation in this case — the inner modal lives inside the drawer's DOM tree, and removing the drawer takes it with it.
+
+If you need a graceful close, dismiss the inner modal first (via `window.modal.hide()` or `turbo_stream.modal(:close)`), then close the drawer.
+
+### Browser back
+
+Neither drawers nor stacked modals push to browser history (`advance: false` is forced for both). Pressing the browser back button navigates the underlying page; both dialogs are removed cleanly via the `turbo:before-cache` handler.
+
+### Backdrop appearance
+
+Each open dialog draws its own `::backdrop`. With both at `overlay: true`, the drawer area appears slightly darker while the modal is open (two semi-transparent overlays stacked). If you don't want the doubled darkness, pass `overlay: false` to the inner modal:
+
+```erb
+<%= modal(title: "Edit preferences", overlay: false) do %>
+  …
+<% end %>
+```
+
+## Constraints
+
+- **Modal from drawer only.** You can't open a drawer from inside a modal, and you can't open another modal from inside a modal. The `drawer-modal` frame is only rendered inside drawers, so any link with `data-turbo-frame="drawer-modal"` from outside a drawer falls through to a normal full-page navigation.
+- **Depth = 2.** Stacked modals don't render their own nested `drawer-modal` frame. Two levels (drawer + modal) is the maximum.
+- **`advance` is forced false.** Stacked modals never push history regardless of the `advance:` option.
+
+## Testing
+
+The demo app includes a showcase tile (`Drawer with nested modal`) and a developer testing page at `/testing/drawers/nested_modal_host` that exercises the edge cases above.

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -7,13 +7,21 @@ Turbo.StreamActions.modal = function () {
   if (message == "hide" || message == "close") window.modal?.hide();
 };
 
+// Frame ids managed by UTMR — primary modal/drawer + stacked-modal frames.
+const MODAL_FRAME_IDS = new Set([
+  'modal',
+  'modal-inner',
+  'drawer-modal',
+  'modal-inner-stacked'
+]);
+
 // Check if the event target is one of our modal Turbo Frames
 const isModalFrameTarget = (event) => {
   const target = event?.target;
   return (
     target instanceof Element &&
     target.tagName.toLowerCase() === 'turbo-frame' &&
-    (target.id === 'modal' || target.id === 'modal-inner')
+    MODAL_FRAME_IDS.has(target.id)
   );
 };
 
@@ -32,20 +40,46 @@ const morphPageBehindModal = (html) => {
     ignoreActiveValue: true,
     callbacks: {
       beforeNodeMorphed: (oldNode) => {
-        if (oldNode.id === 'modal-container') return false;
-        if (oldNode.tagName?.toLowerCase() === 'turbo-frame' &&
-            (oldNode.id === 'modal' || oldNode.id === 'modal-inner')) return false;
+        if (oldNode.id === 'modal-container' || oldNode.id === 'modal-container-stacked') return false;
+        if (oldNode.tagName?.toLowerCase() === 'turbo-frame' && MODAL_FRAME_IDS.has(oldNode.id)) return false;
         return true;
       }
     }
   });
 };
 
+// Count of UTMR dialogs currently in the DOM and open
+const openDialogCount = () =>
+  document.querySelectorAll('dialog.utmr[open]').length;
+
+// Close every open UTMR dialog from top to bottom, awaiting each animation.
+// window.modal always points to the topmost dialog and auto-rotates as each
+// one disconnects, so we just loop until the stack is empty.
+const closeAllDialogs = async () => {
+  // Safety guard against a runaway loop if a dialog refuses to close.
+  let safety = 5;
+  while (window.modal && safety-- > 0) {
+    await window.modal.hideModalWithPromise({ skipHistoryBack: true });
+  }
+};
+
 // Perform a smooth redirect: morph same-page content or close-then-navigate
 const performSmoothRedirect = async (modal, redirectUrl) => {
   const originalUrl = modal.originalUrl;
+  // True when this modal is stacked over another open dialog (e.g., a drawer).
+  // In that case we must NOT morph the body — the morph would clobber the
+  // sibling dialog's DOM. Just close this modal and update the URL.
+  const hasSibling = openDialogCount() > 1;
 
   if (isSamePageUrl(originalUrl, redirectUrl)) {
+    if (hasSibling) {
+      if (redirectUrl !== window.location.href) {
+        history.replaceState({}, '', redirectUrl);
+      }
+      await modal.hideModalWithPromise({ skipHistoryBack: true });
+      return;
+    }
+
     // Same-page: fetch fresh HTML, morph body behind modal, then close
     try {
       const freshResponse = await fetch(redirectUrl, {
@@ -64,8 +98,13 @@ const performSmoothRedirect = async (modal, redirectUrl) => {
     }
     await modal.hideModalWithPromise({ skipHistoryBack: true });
   } else {
-    // Different page: close modal first, then navigate
-    await modal.hideModalWithPromise({ skipHistoryBack: true });
+    // Different page: close every open dialog first (so a sibling drawer
+    // doesn't get stranded on the new page), then navigate.
+    if (hasSibling) {
+      await closeAllDialogs();
+    } else {
+      await modal.hideModalWithPromise({ skipHistoryBack: true });
+    }
     window.Turbo.visit(redirectUrl);
   }
 };
@@ -124,7 +163,7 @@ document.addEventListener("turbo:before-frame-render", handleTurboBeforeFrameRen
 // controller has already disconnected or cleanup failed, the dialog can survive
 // into the cache and leave the page in a broken state on restore.
 const handleTurboBeforeCache = () => {
-  document.querySelectorAll('dialog#modal-container, dialog.drawer-container').forEach(d => {
+  document.querySelectorAll('dialog.utmr').forEach(d => {
     try { d.close(); } catch (_) {}
     d.remove();
   });

--- a/javascript/modal_controller.js
+++ b/javascript/modal_controller.js
@@ -3,6 +3,12 @@ import { Controller } from '@hotwired/stimulus';
 // This placeholder will be replaced by rollup
 const PACKAGE_VERSION = '__PACKAGE_VERSION__';
 
+// Stack of currently-connected modal/drawer controllers, in open order.
+// The topmost (last) entry is exposed as window.modal so existing
+// `window.modal.hide()` and `Turbo.StreamActions.modal` calls always operate
+// on the dialog the user is most directly interacting with.
+const dialogStack = [];
+
 export default class extends Controller {
   static targets = ["container", "content"]
   static values = {
@@ -16,6 +22,8 @@ export default class extends Controller {
     this.turboFrame = this.element.closest('turbo-frame');
     this.hidingModal = this.containerTarget.hasAttribute('data-closing');
     this.originalUrl = window.location.href;
+
+    if (!dialogStack.includes(this)) dialogStack.push(this);
 
     // Same-page morphs can briefly disconnect/reconnect the controller while the
     // dialog is already open. Replaying showModal() there re-triggers the enter
@@ -43,7 +51,7 @@ export default class extends Controller {
     };
     document.addEventListener('turbo:before-cache', this.beforeCacheHandler);
 
-    window.modal = this;
+    window.modal = dialogStack[dialogStack.length - 1];
   }
 
   disconnect() {
@@ -52,7 +60,10 @@ export default class extends Controller {
     this.#cancelCloseCleanup();
     window.removeEventListener('popstate', this.popstateHandler);
     document.removeEventListener('turbo:before-cache', this.beforeCacheHandler);
-    window.modal = undefined;
+
+    const idx = dialogStack.indexOf(this);
+    if (idx !== -1) dialogStack.splice(idx, 1);
+    window.modal = dialogStack[dialogStack.length - 1];
   }
 
   showModal() {
@@ -215,9 +226,7 @@ export default class extends Controller {
 
   #queueCloseCleanup(historyWasAdvanced) {
     const dialog = this.containerTarget;
-    const transitionTarget = this.#isDrawer()
-      ? dialog.querySelector('#drawer-panel')
-      : dialog.querySelector('#modal-inner');
+    const transitionTarget = this.#transitionTarget();
     const closeTimeoutMs = this.#isDrawer() ? 750 : 300;
     this.#cancelCloseCleanup();
 
@@ -265,9 +274,12 @@ export default class extends Controller {
     try { frame.dispatchEvent(new Event('modal:closed', { cancelable: false })); } catch (_) {}
   }
 
-  // Remove any stale dialogs left over from a previous failed close
+  // Remove any stale dialogs of the same kind left over from a previous failed
+  // close. Scoped to the current dialog's id so stacked dialogs don't tear
+  // down their ancestor (e.g. a stacked modal opening inside a drawer).
   #cleanupStaleDialogs() {
-    document.querySelectorAll('dialog#modal-container').forEach(d => {
+    const selector = `dialog#${CSS.escape(this.containerTarget.id)}`;
+    document.querySelectorAll(selector).forEach(d => {
       if (d !== this.containerTarget) {
         try { d.close(); } catch (_) {}
         d.remove();
@@ -277,6 +289,24 @@ export default class extends Controller {
 
   #isDrawer() {
     return this.containerTarget.dataset.drawer !== undefined
+  }
+
+  #isStacked() {
+    return this.containerTarget.id === 'modal-container-stacked';
+  }
+
+  // The element that runs the enter/leave CSS transition. The
+  // `#queueCloseCleanup` listener waits for `transitionend` on this element to
+  // know when the leave animation has completed.
+  //
+  // Note: the inner id (`modal-inner` / `modal-inner-stacked`) is shared by a
+  // wrapping `<turbo-frame>` AND the `<div>` that actually carries the
+  // transition classes. We need the DIV — `querySelector('#modal-inner')`
+  // would return the frame instead.
+  #transitionTarget() {
+    if (this.#isDrawer()) return this.containerTarget.querySelector('#drawer-panel');
+    const innerSelector = this.#isStacked() ? 'div#modal-inner-stacked' : 'div#modal-inner';
+    return this.containerTarget.querySelector(innerSelector);
   }
 
   #queueEnter() {

--- a/lib/generators/ultimate_turbo_modal/templates/flavors/tailwind.rb
+++ b/lib/generators/ultimate_turbo_modal/templates/flavors/tailwind.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 
 # Tailwind CSS v4
+#
+# Group selectors are scoped with the named groups `group/utmr-modal` and
+# `group/utmr-drawer` so that when a modal stacks on top of an open drawer,
+# the inner modal's transition styles don't pick up the outer drawer's
+# `data-entered` state (which would prevent the modal from animating out).
 module UltimateTurboModal::Flavors
   class Tailwind < UltimateTurboModal::Base
-    STYLES = "html:has(dialog#modal-container[open]) { overflow: hidden; }"
+    STYLES = "html:has(dialog#modal-container[open]), html:has(dialog#modal-container-stacked[open]) { overflow: hidden; }"
 
     # Modal constants
 
     MODAL_DIALOG_CLASSES = [
-      "group",
+      "group/utmr-modal",
       # Dialog reset
       "fixed inset-0 p-0 m-0 border-none bg-transparent",
       "max-w-[100vw] max-h-dvh w-full h-full overflow-y-auto",
@@ -24,20 +29,20 @@ module UltimateTurboModal::Flavors
       "flex min-h-full items-start justify-center pt-[10vh] sm:p-4",
       # Transition
       "transition duration-300 ease-out",
-      "group-data-[closing]:duration-200 group-data-[closing]:ease-in",
+      "group-data-[closing]/utmr-modal:duration-200 group-data-[closing]/utmr-modal:ease-in",
       # Default state (closed): faded + shifted
       "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
       # Entered state
-      "group-data-[entered]:opacity-100 group-data-[entered]:translate-y-0 group-data-[entered]:scale-100"
+      "group-data-[entered]/utmr-modal:opacity-100 group-data-[entered]/utmr-modal:translate-y-0 group-data-[entered]/utmr-modal:scale-100"
     ].join(" ")
 
     MODAL_CONTENT_CLASSES = "relative transform max-h-screen overflow-hidden rounded-lg bg-white text-left shadow-lg transition-all sm:my-8 sm:max-w-3xl dark:bg-gray-800 dark:text-white"
-    MODAL_MAIN_CLASSES = "group-data-[padding=true]:p-4 group-data-[padding=true]:pt-2 overflow-y-auto max-h-[75vh]"
-    MODAL_HEADER_CLASSES = "flex justify-between items-center w-full py-4 rounded-t dark:border-gray-600 group-data-[header-divider=true]:border-b group-data-[header=false]:absolute"
+    MODAL_MAIN_CLASSES = "group-data-[padding=true]/utmr-modal:p-4 group-data-[padding=true]/utmr-modal:pt-2 overflow-y-auto max-h-[75vh]"
+    MODAL_HEADER_CLASSES = "flex justify-between items-center w-full py-4 rounded-t dark:border-gray-600 group-data-[header-divider=true]/utmr-modal:border-b group-data-[header=false]/utmr-modal:absolute"
     MODAL_TITLE_CLASSES = "pl-4"
-    MODAL_TITLE_H_CLASSES = "group-data-[title=false]:hidden text-lg font-semibold text-gray-900 dark:text-white"
-    MODAL_FOOTER_CLASSES = "flex p-4 rounded-b dark:border-gray-600 group-data-[footer-divider=true]:border-t"
-    MODAL_CLOSE_CLASSES = "mr-4 group-data-[close-button=false]:hidden"
+    MODAL_TITLE_H_CLASSES = "group-data-[title=false]/utmr-modal:hidden text-lg font-semibold text-gray-900 dark:text-white"
+    MODAL_FOOTER_CLASSES = "flex p-4 rounded-b dark:border-gray-600 group-data-[footer-divider=true]/utmr-modal:border-t"
+    MODAL_CLOSE_CLASSES = "mr-4 group-data-[close-button=false]/utmr-modal:hidden"
     MODAL_CLOSE_SR_CLASSES = "sr-only"
     MODAL_CLOSE_BUTTON_CLASSES = "text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center dark:hover:bg-gray-600 dark:hover:text-white"
     MODAL_CLOSE_ICON_CLASSES = "w-5 h-5"
@@ -45,7 +50,7 @@ module UltimateTurboModal::Flavors
     # Drawer constants
 
     DRAWER_DIALOG_CLASSES = [
-      "group",
+      "group/utmr-drawer",
       # Dialog reset
       "fixed inset-0 p-0 m-0 border-none bg-transparent",
       "max-w-[100vw] max-h-dvh w-full h-full overflow-y-auto",
@@ -75,30 +80,30 @@ module UltimateTurboModal::Flavors
     DRAWER_PANEL_CLASSES = [
       "absolute inset-y-0",
       # Position based on direction
-      "group-data-[drawer=left]:left-0 group-data-[drawer=right]:right-0",
+      "group-data-[drawer=left]/utmr-drawer:left-0 group-data-[drawer=right]/utmr-drawer:right-0",
       # Width (size variable + gutter)
       "w-[min(var(--utmr-w),calc(100vw_-_var(--utmr-gutter)))]",
       # Default: translated off-screen
       "[translate:var(--utmr-hide)]",
       # Entered: in place
-      "group-data-[entered]:[translate:0]",
+      "group-data-[entered]/utmr-drawer:[translate:0]",
       # Closing: back off-screen
-      "group-data-[closing]:[translate:var(--utmr-hide)]",
+      "group-data-[closing]/utmr-drawer:[translate:var(--utmr-hide)]",
       # Transition
       "transition-[translate] duration-250 ease-in-out sm:duration-400",
       "will-change-[translate]",
       # Hidden before animation ready
-      "group-[&:not([data-enter-ready]):not([data-entered])]:invisible"
+      "group-[&:not([data-enter-ready]):not([data-entered])]/utmr-drawer:invisible"
     ].join(" ")
 
-    DRAWER_CONTENT_CLASSES = "relative flex h-full w-full flex-col bg-white group-data-[padding=true]:pt-6 shadow-xl dark:bg-gray-800 dark:text-white"
+    DRAWER_CONTENT_CLASSES = "relative flex h-full w-full flex-col bg-white group-data-[padding=true]/utmr-drawer:pt-6 shadow-xl dark:bg-gray-800 dark:text-white"
 
-    DRAWER_HEADER_CLASSES = "flex items-start justify-between w-full px-4 sm:px-6 group-data-[header-divider=true]:pb-4 group-data-[header-divider=true]:border-b group-data-[header-divider=true]:border-gray-200 dark:group-data-[header-divider=true]:border-gray-600 group-data-[header=false]:hidden"
+    DRAWER_HEADER_CLASSES = "flex items-start justify-between w-full px-4 sm:px-6 group-data-[header-divider=true]/utmr-drawer:pb-4 group-data-[header-divider=true]/utmr-drawer:border-b group-data-[header-divider=true]/utmr-drawer:border-gray-200 dark:group-data-[header-divider=true]/utmr-drawer:border-gray-600 group-data-[header=false]/utmr-drawer:hidden"
     DRAWER_TITLE_CLASSES = ""
-    DRAWER_TITLE_H_CLASSES = "group-data-[title=false]:hidden text-base font-semibold text-gray-900 dark:text-white"
-    DRAWER_MAIN_CLASSES = "relative group-data-[padding=true]:mt-6 flex-1 overflow-y-auto group-data-[padding=true]:px-4 group-data-[padding=true]:sm:px-6 group-data-[padding=true]:pb-6"
-    DRAWER_FOOTER_CLASSES = "flex shrink-0 px-4 py-4 sm:px-6 group-data-[footer-divider=true]:border-t group-data-[footer-divider=true]:border-gray-200 dark:group-data-[footer-divider=true]:border-gray-600"
-    DRAWER_CLOSE_CLASSES = "ml-3 flex h-7 items-center group-data-[close-button=false]:hidden"
+    DRAWER_TITLE_H_CLASSES = "group-data-[title=false]/utmr-drawer:hidden text-base font-semibold text-gray-900 dark:text-white"
+    DRAWER_MAIN_CLASSES = "relative group-data-[padding=true]/utmr-drawer:mt-6 flex-1 overflow-y-auto group-data-[padding=true]/utmr-drawer:px-4 group-data-[padding=true]/utmr-drawer:sm:px-6 group-data-[padding=true]/utmr-drawer:pb-6"
+    DRAWER_FOOTER_CLASSES = "flex shrink-0 px-4 py-4 sm:px-6 group-data-[footer-divider=true]/utmr-drawer:border-t group-data-[footer-divider=true]/utmr-drawer:border-gray-200 dark:group-data-[footer-divider=true]/utmr-drawer:border-gray-600"
+    DRAWER_CLOSE_CLASSES = "ml-3 flex h-7 items-center group-data-[close-button=false]/utmr-drawer:hidden"
     DRAWER_CLOSE_BUTTON_CLASSES = "relative rounded-md text-gray-400 hover:text-gray-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
     DRAWER_CLOSE_SR_CLASSES = MODAL_CLOSE_SR_CLASSES
     DRAWER_CLOSE_ICON_CLASSES = "size-6"

--- a/lib/generators/ultimate_turbo_modal/templates/flavors/vanilla.rb
+++ b/lib/generators/ultimate_turbo_modal/templates/flavors/vanilla.rb
@@ -5,7 +5,7 @@
 # Set STYLES to a CSS string if you need additional inline styles.
 module UltimateTurboModal::Flavors
   class Vanilla < UltimateTurboModal::Base
-    STYLES = "html:has(dialog#modal-container[open]) { overflow: hidden; }"
+    STYLES = "html:has(dialog#modal-container[open]), html:has(dialog#modal-container-stacked[open]) { overflow: hidden; }"
 
     MODAL_DIALOG_CLASSES = "modal-container"
     MODAL_INNER_CLASSES = "modal-inner"

--- a/lib/ultimate_turbo_modal/base.rb
+++ b/lib/ultimate_turbo_modal/base.rb
@@ -39,6 +39,9 @@ class UltimateTurboModal::Base < Phlex::HTML
     request: nil, title: nil
   )
     @drawer = drawer_position
+    @request = request
+
+    raise ArgumentError, "Cannot render a drawer into the drawer-modal frame (drawers cannot be opened from inside another drawer or modal)" if drawer? && stacked?
 
     if drawer?
       cfg = UltimateTurboModal.configuration.drawer_config
@@ -60,11 +63,15 @@ class UltimateTurboModal::Base < Phlex::HTML
     @overlay = overlay.nil? ? cfg.overlay : overlay
     @padding = padding.nil? ? cfg.padding : padding
 
+    if stacked?
+      @advance = false
+      @advance_url = nil
+    end
+
     @allowed_click_outside_selector = allowed_click_outside_selector
     @close_button_data_action = close_button_data_action
     @close_button_sr_label = close_button_sr_label
     @content_div_data = content_div_data
-    @request = request
     @title = title
 
     self.class.include_turbo_helpers
@@ -84,12 +91,16 @@ class UltimateTurboModal::Base < Phlex::HTML
 
   def view_template(&block)
     if turbo_frame?
-      turbo_frame_tag("modal") do
+      turbo_frame_tag(turbo_frame_name) do
         drawer? ? render_drawer(&block) : render_modal(&block)
       end
     else
       render block
     end
+  end
+
+  def turbo_frame_name
+    stacked? ? "drawer-modal" : "modal"
   end
 
   def title(&block)
@@ -144,6 +155,16 @@ class UltimateTurboModal::Base < Phlex::HTML
   def advance? = !!@advance && !!@advance_url
 
   def drawer? = !!@drawer
+
+  def stacked? = request&.headers&.[]("Turbo-Frame") == "drawer-modal"
+
+  def dialog_id = stacked? ? "modal-container-stacked" : "modal-container"
+
+  def inner_id = stacked? ? "modal-inner-stacked" : "modal-inner"
+
+  # Suffix inner ids so they don't collide with the drawer's ids when the
+  # stacked modal is rendered inside the drawer's DOM.
+  def scoped_id(name) = stacked? ? "#{name}-stacked" : name
 
   def drawer_position = @drawer || :right
 
@@ -262,11 +283,11 @@ class UltimateTurboModal::Base < Phlex::HTML
       inline_style = "--utmr-w: #{@drawer_size}"
     end
 
-    dialog(id: "modal-container",
+    dialog(id: dialog_id,
       class: dialog_classes,
       style: inline_style,
       aria: {
-        labelledby: "modal-title-h"
+        labelledby: scoped_id("modal-title-h")
       },
       data: data_attributes, &block)
   end
@@ -274,14 +295,14 @@ class UltimateTurboModal::Base < Phlex::HTML
   ## Modal-specific elements
 
   def modal_inner(&block)
-    maybe_turbo_frame("modal-inner") do
-      div(id: "modal-inner", class: self.class::MODAL_INNER_CLASSES, &block)
+    maybe_turbo_frame(inner_id) do
+      div(id: inner_id, class: self.class::MODAL_INNER_CLASSES, &block)
     end
   end
 
   def modal_content(&block)
     data = (content_div_data || {}).merge({modal_target: "content"})
-    div(id: "modal-content", class: self.class::MODAL_CONTENT_CLASSES, data: data, &block)
+    div(id: scoped_id("modal-content"), class: self.class::MODAL_CONTENT_CLASSES, data: data, &block)
   end
 
   def modal_main(&block) = render_main(&block)
@@ -294,7 +315,12 @@ class UltimateTurboModal::Base < Phlex::HTML
 
   def drawer_wrapper(&block)
     maybe_turbo_frame("modal-inner") do
-      div(id: "drawer-wrapper", class: self.class::DRAWER_WRAPPER_CLASSES, &block)
+      div(id: "drawer-wrapper", class: self.class::DRAWER_WRAPPER_CLASSES) do
+        yield
+        # Empty frame so links inside the drawer can target a stacked modal
+        # via data-turbo-frame="drawer-modal". Always rendered.
+        turbo_frame_tag("drawer-modal")
+      end
     end
   end
 
@@ -320,34 +346,34 @@ class UltimateTurboModal::Base < Phlex::HTML
   ## Shared rendering
 
   def render_main(&block)
-    div(id: "modal-main", class: classes_for("MAIN_CLASSES"), &block)
+    div(id: scoped_id("modal-main"), class: classes_for("MAIN_CLASSES"), &block)
   end
 
   def render_header
-    div(id: "modal-header", class: classes_for("HEADER_CLASSES")) do
+    div(id: scoped_id("modal-header"), class: classes_for("HEADER_CLASSES")) do
       render_title
       drawer? ? drawer_close : modal_close
     end
   end
 
   def render_title
-    div(id: "modal-title", class: classes_for("TITLE_CLASSES")) do
+    div(id: scoped_id("modal-title"), class: classes_for("TITLE_CLASSES")) do
       if @title_block.present?
         render @title_block
       else
-        h3(id: "modal-title-h", class: classes_for("TITLE_H_CLASSES")) { @title }
+        h3(id: scoped_id("modal-title-h"), class: classes_for("TITLE_H_CLASSES")) { @title }
       end
     end
   end
 
   def render_footer
-    div(id: "modal-footer", class: classes_for("FOOTER_CLASSES")) do
+    div(id: scoped_id("modal-footer"), class: classes_for("FOOTER_CLASSES")) do
       render @footer
     end
   end
 
   def render_close
-    div(id: "modal-close", class: classes_for("CLOSE_CLASSES")) do
+    div(id: scoped_id("modal-close"), class: classes_for("CLOSE_CLASSES")) do
       close_button_tag(classes_for("CLOSE_BUTTON_CLASSES")) do
         yield if block_given?
         close_icon_svg(classes_for("CLOSE_ICON_CLASSES"))


### PR DESCRIPTION
## Summary
- Drawers now always render an empty `<turbo-frame id="drawer-modal">`. Any link inside a drawer with `data-turbo-frame="drawer-modal"` opens a modal stacked on top of the drawer; ESC, click-outside, the close button, `turbo_stream.modal(:close)`, and form submissions (smooth same-page redirect or close-all + visit) all behave correctly with the dialog stack.
- The Tailwind flavor switches to named groups (`group/utmr-modal`, `group/utmr-drawer`) so the inner modal's transition styles don't pick up the outer drawer's `data-entered` state — without this fix the leave animation never fired and the modal would just disappear.
- Inner element ids on the stacked modal are suffixed with `-stacked` to keep the DOM valid; the Stimulus controller's `transitionend` lookup now disambiguates the inner `<div>` from the wrapping `<turbo-frame>` (they share an id) so cleanup fires on the actual transition end.
- Demo app gets a "Modal from Drawer" showcase tile, a `/testing/drawers/nested_modal_host` testing page that exercises ESC / outside-click / same-page redirect / different-page redirect, and a small Contact form refactor that backs the existing form-modal demo with an Active Model. Docs: new README section, `docs/modal-from-drawer.md`, CHANGELOG entry.

## Test plan
- [ ] Open the showcase "Modal from Drawer" tile — drawer slides in, "Edit preferences" opens the modal on top.
- [ ] ESC closes the inner modal first (with fade/scale animation), then a second ESC closes the drawer.
- [ ] Click outside the inner modal closes inner only; the drawer stays.
- [ ] Submit the inner modal's form — modal closes smoothly, drawer remains.
- [ ] Verify `/testing/drawers/nested_modal_host` scenarios: basic, long content, no overlay, same-page redirect, different-page redirect.
- [ ] Switch to vanilla flavor (`?flavor=vanilla`) and re-run the same scenarios.
- [ ] Confirm regular single-modal behavior is unchanged (Basic Modal tile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)