### PR TITLE
Fix race in closeAllDialogs when stacked modal redirects off-page

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -53,13 +53,23 @@ const openDialogCount = () =>
   document.querySelectorAll('dialog.utmr[open]').length;
 
 // Close every open UTMR dialog from top to bottom, awaiting each animation.
-// window.modal always points to the topmost dialog and auto-rotates as each
-// one disconnects, so we just loop until the stack is empty.
+// window.modal points to the topmost dialog and auto-rotates as each one
+// disconnects.
+//
+// Subtlety: hideModalWithPromise resolves on `modal:closed`, but window.modal
+// is only rotated inside Stimulus's disconnect (fired by MutationObserver
+// after the dialog is removed from the DOM). We yield once after each close
+// so disconnect has a chance to run before the next iteration reads
+// window.modal — otherwise we'd loop on the same already-hiding controller
+// and burn through the safety counter. We also bail out when window.modal
+// hasn't rotated, which catches `modal:closing` vetoes (preventDefault).
 const closeAllDialogs = async () => {
-  // Safety guard against a runaway loop if a dialog refuses to close.
   let safety = 5;
   while (window.modal && safety-- > 0) {
-    await window.modal.hideModalWithPromise({ skipHistoryBack: true });
+    const ctrl = window.modal;
+    await ctrl.hideModalWithPromise({ skipHistoryBack: true });
+    await new Promise(r => setTimeout(r, 0));
+    if (window.modal === ctrl) break;
   }
 };
 

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -901,6 +901,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },


### PR DESCRIPTION
## Summary
Follow-up to #57 (codex review catch). `closeAllDialogs` looped on `window.modal`, but `hideModalWithPromise` resolves on `modal:closed` (dispatched synchronously in cleanup) whereas `window.modal` is only rotated inside Stimulus's `disconnect` (a later MutationObserver microtask). The loop could re-target the same already-hiding controller and exhaust the safety counter, leaving the underlying drawer visible/interactive on a different-page redirect from the stacked modal. A `modal:closing` veto via `preventDefault()` had the same effect.

The fix snapshots `window.modal` before each `await`, yields once with `setTimeout(0)` so `disconnect` can fire, and breaks out if `window.modal` hasn't rotated.

## Test plan
- [ ] Open showcase "Modal from Drawer" → drawer + stacked modal.
- [ ] Submit a form inside the inner modal that redirects to a *different* page → both dialogs close, page navigates.
- [ ] Add a temporary `modal:closing` listener that calls `preventDefault()` on the inner modal, attempt to close → loop bails out instead of spinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)