### PR TITLE
Vertically center modals on desktop with optical bias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
-- Added support for opening a modal from inside a drawer. Any link inside a drawer with `data-turbo-frame="drawer-modal"` will now open a modal stacked on top of the drawer. ESC, click-outside, and form submissions handle the stacked case correctly. See [docs/modal-from-drawer.md](docs/modal-from-drawer.md).
+- Tweaked vertically centering of modals on desktop (≥640px) with a slight optical-center bias, instead of anchoring them near the top.
+- Added support for opening a modal from inside a drawer. See [docs/modal-from-drawer.md](docs/modal-from-drawer.md).
 
 ## [3.0.5] - 2026-04-22
 

--- a/javascript/styles/vanilla.css
+++ b/javascript/styles/vanilla.css
@@ -70,7 +70,7 @@ dialog.utmr {
   .modal-inner {
     display: flex;
     padding: 0.25rem;
-    padding-top: 5vh;
+    padding-top: 10vh;
     justify-content: center;
     align-items: flex-start;
     min-height: 100%;
@@ -80,7 +80,8 @@ dialog.utmr {
 
     @media (min-width: 640px) {
       padding: 1rem;
-      padding-top: 5vh;
+      padding-bottom: 10vh;
+      align-items: center;
       translate: none;
       scale: 0.95;
     }
@@ -141,8 +142,6 @@ dialog.utmr {
     max-height: 100vh;
 
     @media (min-width: 640px) {
-      margin-top: 2rem;
-      margin-bottom: 2rem;
       max-width: 48rem;
     }
   }

--- a/lib/generators/ultimate_turbo_modal/templates/flavors/tailwind.rb
+++ b/lib/generators/ultimate_turbo_modal/templates/flavors/tailwind.rb
@@ -26,7 +26,7 @@ module UltimateTurboModal::Flavors
     ].join(" ")
 
     MODAL_INNER_CLASSES = [
-      "flex min-h-full items-start justify-center pt-[10vh] sm:p-4",
+      "flex min-h-full items-start justify-center pt-[10vh] sm:items-center sm:pt-0 sm:p-4 sm:pb-[10vh]",
       # Transition
       "transition duration-300 ease-out",
       "group-data-[closing]/utmr-modal:duration-200 group-data-[closing]/utmr-modal:ease-in",
@@ -36,7 +36,7 @@ module UltimateTurboModal::Flavors
       "group-data-[entered]/utmr-modal:opacity-100 group-data-[entered]/utmr-modal:translate-y-0 group-data-[entered]/utmr-modal:scale-100"
     ].join(" ")
 
-    MODAL_CONTENT_CLASSES = "relative transform max-h-screen overflow-hidden rounded-lg bg-white text-left shadow-lg transition-all sm:my-8 sm:max-w-3xl dark:bg-gray-800 dark:text-white"
+    MODAL_CONTENT_CLASSES = "relative transform max-h-screen overflow-hidden rounded-lg bg-white text-left shadow-lg transition-all sm:max-w-3xl dark:bg-gray-800 dark:text-white"
     MODAL_MAIN_CLASSES = "group-data-[padding=true]/utmr-modal:p-4 group-data-[padding=true]/utmr-modal:pt-2 overflow-y-auto max-h-[75vh]"
     MODAL_HEADER_CLASSES = "flex justify-between items-center w-full py-4 rounded-t dark:border-gray-600 group-data-[header-divider=true]/utmr-modal:border-b group-data-[header=false]/utmr-modal:absolute"
     MODAL_TITLE_CLASSES = "pl-4"


### PR DESCRIPTION
## Summary
- Vertically center modals on desktop (≥640px) with a slight optical bias above geometric center, instead of anchoring them near the top of the viewport with a large empty gap below.
- Mobile keeps a top-anchored offset (10vh on both Tailwind and vanilla — vanilla was previously 5vh, now matches Tailwind) so there's room for the on-screen keyboard.
- Drawers are untouched.

### Implementation
- **Tailwind** (`lib/generators/ultimate_turbo_modal/templates/flavors/tailwind.rb`): `MODAL_INNER_CLASSES` switches to `sm:items-center sm:pt-0 sm:p-4 sm:pb-[10vh]` on desktop. Removed the now-redundant `sm:my-8` from `MODAL_CONTENT_CLASSES`.
- **Vanilla** (`javascript/styles/vanilla.css`): `.modal-inner` mobile uses `padding-top: 10vh` (was 5vh); the `@media (min-width: 640px)` block sets `align-items: center` with balanced padding (`padding: 1rem; padding-bottom: 10vh`). Removed the redundant `margin-top/bottom: 2rem` from `.modal-content`'s desktop block.

## Test plan
Verified in Chrome via dev-browser at desktop (1280×800) and mobile (375×667) viewports for both flavors:

- [x] Tailwind desktop, basic modal: content center at 45% of viewport height (slightly above geometric center)
- [x] Tailwind desktop, long content: fits 27.5–692.5px, inner area scrolls correctly
- [x] Tailwind mobile, basic modal: content top at exactly 10vh
- [x] Vanilla desktop, basic modal: content center at 46% of viewport height
- [x] Vanilla desktop, long content: fits 35.5–700.5px, inner area scrolls correctly
- [x] Vanilla mobile, basic modal: content top at 10vh (matches Tailwind)
- [x] Tailwind right drawer: full-height, pinned right, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)