### PR TITLE
Fix scroll-lock leak when modal controller reconnects via same-page morph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fixed scroll-lock not releasing after a same-page morph reconnected the modal controller, which could leave the page padded and right-anchored fixed elements offset until refresh.
+
 ## [3.1.2] - 2026-05-01
 
 - Fixed page content shifting right when a modal or drawer opens.

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
-        "setup": "./.conductor/setup.sh",
-        "run": "./.conductor/run.sh",
+        "setup": "mise exec -- ./.conductor/setup.sh",
+        "run": "mise exec -- ./.conductor/run.sh",
     }
 }
 

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../javascript": {
       "name": "ultimate_turbo_modal",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@hotwired/turbo-rails": "^8.0.0",

--- a/javascript/modal_controller.js
+++ b/javascript/modal_controller.js
@@ -40,9 +40,12 @@ export default class extends Controller {
     // dialog is already open. Replaying showModal() there re-triggers the enter
     // animation and causes a visible reopen during close.
     if (this.hidingModal) {
+      this.#adoptScrollLock();
       this.#resumeClosing();
     } else if (!this.containerTarget.open) {
       this.showModal();
+    } else {
+      this.#adoptScrollLock();
     }
 
     // When the user presses the browser back button, Turbo handles the
@@ -72,6 +75,7 @@ export default class extends Controller {
     this.#cancelCloseCleanup();
     window.removeEventListener('popstate', this.popstateHandler);
     document.removeEventListener('turbo:before-cache', this.beforeCacheHandler);
+    this.#releaseScrollLockSlot();
 
     const idx = dialogStack.indexOf(this);
     if (idx !== -1) dialogStack.splice(idx, 1);
@@ -394,15 +398,44 @@ export default class extends Controller {
     scrollLockOwners.delete(this);
     this._holdsScrollLock = false;
     if (scrollLockOwners.size === 0 && scrollbarPaddingApplied) {
-      document.documentElement.style.paddingRight = savedPaddingRight;
-      savedPaddingRight = '';
-      compensatedFixedElements.forEach(({ el, originalRight }) => {
-        if (originalRight) el.style.right = originalRight;
-        else el.style.removeProperty('right');
-      });
-      compensatedFixedElements = [];
-      scrollbarPaddingApplied = false;
+      this.#restoreScrollbarCompensation();
     }
+  }
+
+  // Take ownership of an existing scroll lock when reconnecting to a dialog
+  // that's already open (e.g. same-page morph). The actual padding/offset
+  // compensation is already applied by the previous controller instance — we
+  // just need to register so the eventual close releases it.
+  #adoptScrollLock() {
+    if (this._holdsScrollLock) return;
+    if (!scrollbarPaddingApplied) return;
+    scrollLockOwners.add(this);
+    this._holdsScrollLock = true;
+  }
+
+  // Release this controller's slot in the scroll-lock set during disconnect.
+  // Compensation restoration is deferred so an immediate Stimulus reconnect
+  // (same-page morph) can adopt the lock before everything is torn down.
+  #releaseScrollLockSlot() {
+    if (!this._holdsScrollLock) return;
+    scrollLockOwners.delete(this);
+    this._holdsScrollLock = false;
+    queueMicrotask(() => {
+      if (scrollLockOwners.size === 0 && scrollbarPaddingApplied) {
+        this.#restoreScrollbarCompensation();
+      }
+    });
+  }
+
+  #restoreScrollbarCompensation() {
+    document.documentElement.style.paddingRight = savedPaddingRight;
+    savedPaddingRight = '';
+    compensatedFixedElements.forEach(({ el, originalRight }) => {
+      if (originalRight) el.style.right = originalRight;
+      else el.style.removeProperty('right');
+    });
+    compensatedFixedElements = [];
+    scrollbarPaddingApplied = false;
   }
 
   #hasHistoryAdvanced() {


### PR DESCRIPTION
## Summary

- Fixes a scroll-lock leak surfaced by an LLM code-review flag (P1). When a same-page morph briefly disconnected and reconnected the modal controller while the dialog was open, the old instance's entry in `scrollLockOwners` was never released and the new instance never re-took ownership, so on close the `<html>` `padding-right` and right-anchored fixed-element offsets stayed stuck until refresh.
- The reconnect path in `connect()` now adopts the existing scroll lock, and `disconnect()` releases its slot with a deferred restoration that lets an immediate Stimulus reconnect take over before everything is torn down.
- Also wires `mise exec --` into the local `conductor.json` setup/run scripts and syncs `demo-app/package-lock.json` to the current 3.1.2 version.

## Test plan

- [x] Programmatic console test: open a modal, detach + reattach the dialog to simulate morph, close — `document.documentElement.style.paddingRight` is empty after close (was stuck before fix).
- [ ] Verify normal close paths still clear compensation: X button, ESC, click-outside, form submit redirect, browser back with `advance: true`, Turbo cache restore.
- [ ] Verify stacked-modal open/close leaves no residual padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)