### PR TITLE
[codex] Auto-route modal targets inside drawers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Links and forms inside a drawer can now use `data-turbo-frame="modal"` to open a stacked modal — the same partial works inside or outside a drawer with no changes.
 - Fixed scroll-lock not releasing after a same-page morph reconnected the modal controller, which could leave the page padded and right-anchored fixed elements offset until refresh.
 
 ## [3.1.2] - 2026-05-01

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,8 @@ Uses a `data-turbo-modal-history-advanced` attribute on `<body>` to track whethe
 
 ### Turbo Frame Integration (index.js)
 - `turbo:frame-missing` handler: When a response redirects and the target is a modal frame, it escapes the modal and performs a full Turbo visit
-- `turbo:before-frame-render` handler: Uses Idiomorph with `morphstyle: 'innerHTML'` for modal frames, preventing flicker and re-triggering of enter transitions
+- `turbo:before-frame-render` handler: Lets empty modal frames render normally, then uses Idiomorph with `morphStyle: 'innerHTML'` for subsequent modal-frame updates to prevent flicker and re-triggering enter transitions
+- Drawer content normalization retargets links/forms/buttons inside a drawer from `data-turbo-frame="modal"` to `data-turbo-frame="drawer-modal"` once they are in the drawer DOM. Turbo then handles normal clicks/submissions itself and sends `Turbo-Frame: drawer-modal`. This lets a single partial use `data-turbo-frame="modal"` everywhere — outside a drawer it opens a regular modal; inside a drawer it opens a stacked one.
 - Event listeners are added with a preceding `removeEventListener` to prevent duplicates on hot reload
 
 ### Turbo Cache Handling

--- a/README.md
+++ b/README.md
@@ -205,20 +205,16 @@ Link to it the same way as a modal:
 
 ## Opening a Modal from a Drawer
 
-You can open a regular modal that stacks on top of an open drawer. This is built in — no setup or opt-in required.
-
-Inside any drawer, link to a modal action with `data-turbo-frame="drawer-modal"`:
+You don't need to do anything special. Use `data-turbo-frame="modal"` like you would anywhere else, and UTMR handles the rest:
 
 ```erb
 <%= drawer(title: "Notifications") do %>
   <p>Activity list here…</p>
   <%= link_to "Edit preferences",
         edit_preferences_path,
-        data: { turbo_frame: "drawer-modal" } %>
+        data: { turbo_frame: "modal" } %>
 <% end %>
 ```
-
-The destination is rendered with the same `modal()` helper you use elsewhere:
 
 ```erb
 <%= modal(title: "Notification preferences") do %>
@@ -226,7 +222,7 @@ The destination is rendered with the same `modal()` helper you use elsewhere:
 <% end %>
 ```
 
-The gem detects the request and renders the modal into a stacked `<dialog>` that sits visually on top of the drawer.
+The same partial works inside a drawer or out — outside, it opens a regular modal; inside, it stacks on top of the drawer.
 
 ### Behavior
 

--- a/demo-app/app/views/showcase/show.html.erb
+++ b/demo-app/app/views/showcase/show.html.erb
@@ -253,7 +253,7 @@
       <div class="pt-2">
         <%= link_to "Edit preferences →",
               showcase_path(:nested_modal_form),
-              data: { turbo_frame: "drawer-modal" },
+              data: { turbo_frame: "modal" },
               class: "inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500" %>
       </div>
     </div>

--- a/demo-app/app/views/testing/drawers/show.html.erb
+++ b/demo-app/app/views/testing/drawers/show.html.erb
@@ -65,24 +65,36 @@
         <li>
           <%= link_to "Open nested modal (basic)",
                 nested_modal_testing_drawers_path,
-                data: { turbo_frame: "drawer-modal" } %>
+                data: { turbo_frame: "modal" } %>
         </li>
         <li>
           <%= link_to "Open nested modal (long content)",
                 nested_modal_testing_drawers_path(scenario: :long),
-                data: { turbo_frame: "drawer-modal" } %>
+                data: { turbo_frame: "modal" } %>
         </li>
         <li>
           <%= link_to "Open nested modal (no overlay)",
                 nested_modal_testing_drawers_path(scenario: :no_overlay),
-                data: { turbo_frame: "drawer-modal" } %>
+                data: { turbo_frame: "modal" } %>
         </li>
         <li>
           <%= link_to "Open nested form (validation + multi-step)",
                 nested_form_testing_drawers_path,
+                data: { turbo_frame: "modal" } %>
+        </li>
+        <li>
+          <%= link_to "Open nested modal (explicit drawer-modal target)",
+                nested_modal_testing_drawers_path,
                 data: { turbo_frame: "drawer-modal" } %>
         </li>
       </ul>
+
+      <p class="text-sm text-gray-500 dark:text-gray-400 pt-4 border-t mt-4">
+        The first four links use <code>data-turbo-frame="modal"</code> — the
+        same attribute you'd use outside a drawer. UTMR auto-routes them to
+        the stacked-modal frame because they live inside the drawer. The last
+        link still works with the explicit <code>drawer-modal</code> target.
+      </p>
 
       <p class="text-sm text-gray-500 dark:text-gray-400 pt-4 border-t mt-4">
         Test cases: ESC closes inner modal first, then drawer.

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -1001,6 +1001,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1255,7 +1256,8 @@
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
       "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
@@ -1886,6 +1888,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2208,7 +2211,8 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",

--- a/docs/modal-from-drawer.md
+++ b/docs/modal-from-drawer.md
@@ -4,13 +4,13 @@ Ultimate Turbo Modal supports opening a regular modal that stacks visually on to
 
 ## Quick start
 
-Inside any drawer, link to a modal action with `data-turbo-frame="drawer-modal"`:
+Inside any drawer, link to a modal action with `data-turbo-frame="modal"` — the same attribute you'd use anywhere else:
 
 ```erb
 <%= drawer(title: "Notifications") do %>
   <%= link_to "Edit preferences",
         edit_preferences_path,
-        data: { turbo_frame: "drawer-modal" } %>
+        data: { turbo_frame: "modal" } %>
 <% end %>
 ```
 
@@ -26,9 +26,13 @@ The target action renders with the standard `modal()` helper — no special API.
 
 That's it. No layout change, no opt-in.
 
+The same partial works whether it's rendered inside or outside a drawer: outside, the link opens a regular modal; inside, it opens a stacked one.
+
 ## How it works
 
-Drawers always render an empty `<turbo-frame id="drawer-modal">` inside their DOM, alongside the visible drawer panel. When a link inside the drawer targets that frame, Turbo loads the response into it — and because the response is rendered with `modal()`, it's a `<dialog>` that gets pushed onto the browser's native top layer above the drawer.
+Drawers always render an empty `<turbo-frame id="drawer-modal">` inside their DOM, alongside the visible drawer panel. When drawer content renders, UTMR normalizes modal-targeted links/forms/buttons inside that drawer from `data-turbo-frame="modal"` to `data-turbo-frame="drawer-modal"`. Turbo then handles normal clicks and submissions itself: it sends the request with `Turbo-Frame: drawer-modal`, loads the response into the empty stacked frame, and `modal()` renders a `<dialog>` pushed onto the browser's native top layer above the drawer.
+
+If you'd prefer to be explicit, `data-turbo-frame="drawer-modal"` works directly and skips the automatic routing.
 
 Internally:
 
@@ -43,8 +47,9 @@ Internally:
    ├─ <dialog id="modal-container">
    └─ contains an empty <turbo-frame id="drawer-modal">
 
-2. Link inside drawer with data-turbo-frame="drawer-modal" is clicked
-   ├─ Turbo loads response into the empty frame
+2. Link inside drawer with data-turbo-frame="modal" is clicked
+   ├─ UTMR has already normalized the target to drawer-modal
+   ├─ Turbo fetches with Turbo-Frame: drawer-modal
    └─ Response is rendered by modal() with stacked ids
 
 3. Stacked modal connects

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -154,19 +154,99 @@ const handleTurboBeforeFrameRender = (event) => {
     modal._pendingRedirectUrl = null;
   }
 
-  // Morph innerHTML to prevent flicker and avoid re-triggering enter transitions
+  // Empty modal frames are initial loads. Let Turbo do its normal child
+  // replacement so Stimulus sees a plain insertion and owns dialog opening.
+  if (event.target.children.length === 0) return;
+
+  // Morph subsequent in-frame updates to prevent flicker and avoid re-running
+  // enter transitions on an already-open dialog.
   event.detail.render = (currentElement, newElement) => {
-    Idiomorph.morph(currentElement, newElement, {
-      morphstyle: 'innerHTML'
-    })
-  }
+    Idiomorph.morph(currentElement, Array.from(newElement.childNodes), {
+      morphStyle: 'innerHTML'
+    });
+  };
 };
+
+// Auto-route modal-bound clicks/submissions to the drawer's stacked-modal
+// frame when they originate from inside an open drawer. Lets a partial use
+// `data-turbo-frame="modal"` everywhere — outside a drawer it opens a regular
+// modal, inside a drawer it opens stacked. No `data-turbo-frame` still means
+// "navigate inside the drawer".
+//
+// Basic strategy: once drawer content is in the DOM, normalize its
+// modal-targeted links/forms/buttons to target the drawer's local stacked frame.
+// Turbo then handles normal clicks and submissions itself, including sending
+// `Turbo-Frame: drawer-modal`.
+
+const ORIGINAL_TURBO_FRAME_ATTR = 'data-utmr-original-turbo-frame';
+const DRAWER_TARGET_OBSERVER_KEY = '__utmrDrawerTargetObserver';
+
+const drawerDialogsFor = (root = document) => {
+  const dialogs = new Set();
+
+  if (root instanceof Element) {
+    const owningDrawer = root.closest('dialog.utmr[data-drawer]');
+    if (owningDrawer) dialogs.add(owningDrawer);
+    if (root.matches('dialog.utmr[data-drawer]')) dialogs.add(root);
+    root.querySelectorAll('dialog.utmr[data-drawer]').forEach((dialog) => dialogs.add(dialog));
+  } else {
+    document.querySelectorAll('dialog.utmr[data-drawer]').forEach((dialog) => dialogs.add(dialog));
+  }
+
+  return dialogs;
+};
+
+const routeDrawerModalTargets = (root = document) => {
+  drawerDialogsFor(root).forEach((dialog) => {
+    if (!dialog.querySelector('turbo-frame#drawer-modal')) return;
+
+    dialog.querySelectorAll('[data-turbo-frame="modal"]').forEach((target) => {
+      // Do not retarget controls inside a stacked modal rendered within the drawer.
+      if (target.closest('dialog.utmr') !== dialog) return;
+
+      if (!target.hasAttribute(ORIGINAL_TURBO_FRAME_ATTR)) {
+        target.setAttribute(ORIGINAL_TURBO_FRAME_ATTR, 'modal');
+      }
+      target.setAttribute('data-turbo-frame', 'drawer-modal');
+    });
+  });
+};
+
+const handleTurboFrameRender = (event) => {
+  if (!isModalFrameTarget(event)) return;
+  routeDrawerModalTargets(event.target);
+};
+
+window[DRAWER_TARGET_OBSERVER_KEY]?.disconnect?.();
+window[DRAWER_TARGET_OBSERVER_KEY] = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    if (mutation.type === 'attributes') {
+      routeDrawerModalTargets(mutation.target);
+      return;
+    }
+
+    mutation.addedNodes.forEach((node) => {
+      if (node instanceof Element) routeDrawerModalTargets(node);
+    });
+  });
+});
+
+routeDrawerModalTargets();
+window[DRAWER_TARGET_OBSERVER_KEY].observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+  attributes: true,
+  attributeFilter: ['data-turbo-frame']
+});
 
 document.removeEventListener("turbo:frame-missing", handleTurboFrameMissing);
 document.addEventListener("turbo:frame-missing", handleTurboFrameMissing);
 
 document.removeEventListener("turbo:before-frame-render", handleTurboBeforeFrameRender);
 document.addEventListener("turbo:before-frame-render", handleTurboBeforeFrameRender);
+
+document.removeEventListener("turbo:frame-render", handleTurboFrameRender);
+document.addEventListener("turbo:frame-render", handleTurboFrameRender);
 
 // Clean up any modal dialogs before Turbo caches the page.
 // The Stimulus controller has its own turbo:before-cache handler, but if the

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -901,6 +901,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },


### PR DESCRIPTION
## Summary
Auto-routes drawer-local `data-turbo-frame="modal"` targets to the drawer's `drawer-modal` frame once drawer content renders, so shared partials open stacked modals without full-page navigation.
Keeps initial modal frame renders on Turbo's default path and uses Idiomorph only for populated modal-frame updates to avoid flicker.
Updates the changelog, README, docs, demo and testing views, and npm lockfile metadata that changed during the build.

## Validation
Ran `cd javascript && npm run build`; verified in Chrome that the drawer link is normalized to `drawer-modal`, the URL stays on the host page, and `modal-container-stacked` renders inside `turbo-frame#drawer-modal`.