### PR TITLE
Allow drawers to advance URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Drawers now support the `advance` option to push their URL to browser history, matching modals. Defaults to `false`.
+
 ## [3.2.1] - 2026-05-07
 
 - Fixed drawers closing abruptly when pressing Escape after dismissing a modal opened from inside the drawer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ Options can be set at three levels (lowest wins):
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `position` | `:right`, `:left` | `:right` | Which edge the drawer slides from |
+| `advance` | Boolean or String | `false` | Push URL to browser history; String for custom URL |
 | `close_button` | Boolean | `true` | Show close button |
 | `header` | Boolean | `true` | Show header section |
 | `header_divider` | Boolean | `false` | Show divider below header |
@@ -165,8 +166,6 @@ Options can be set at three levels (lowest wins):
 | `padding` | Boolean | `true` | Add padding to drawer content |
 | `overlay` | Boolean | `true` | Show backdrop overlay |
 | `size` | Symbol or String | `:md` | Drawer width: `:xs`, `:sm`, `:md`, `:lg`, `:xl`, `:"2xl"`, `:full`, or CSS string |
-
-Note: `advance` is always `false` for drawers and cannot be configured.
 
 ### Per-Instance Only Options
 
@@ -351,7 +350,7 @@ Turbo helpers (`Turbo::FramesHelper`, `Turbo::StreamsHelper`, etc.) are included
 `Base` implements these to delegate to included modules. This is needed because Phlex components use a different method resolution order than typical Rails views.
 
 ### History Management
-Uses a `data-turbo-modal-history-advanced` attribute on `<body>` to track whether `history.pushState` was called. The popstate listener resets the modal when the user navigates back. History advance is auto-disabled for drawers.
+Uses a `data-turbo-modal-history-advanced` attribute on `<body>` to track whether `history.pushState` was called. The popstate listener resets the modal when the user navigates back. Stacked modals (modal-on-drawer) always force `advance: false` so the drawer's URL stays in the bar.
 
 ### Outside Click Handling
 `dialogClicked` handles clicks on the dialog element itself (which is full-screen). It dismisses if the click is outside `contentTarget` and not on an element matching `allowedClickOutsideSelectorValue`.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ UltimateTurboModal.configure do |config|
 
   config.drawer do |d|
     d.position = :right
+    d.advance = false
     d.close_button = true
     d.header = true
     d.header_divider = false
@@ -177,6 +178,7 @@ Link to it the same way as a modal:
 |------|---------|-------------|
 | `position` | `:right` | Which edge the drawer slides from. `:right` or `:left`. |
 | `size` | `:md` | Width of the drawer. One of `:xs`, `:sm`, `:md`, `:lg`, `:xl`, `:"2xl"`, `:full`, or a CSS string (e.g. `"500px"`). |
+| `advance` | `false` | When opening the drawer, the URL in the URL bar will change to the URL of the view being shown in the drawer. The Back button dismisses the drawer and navigates back. If a URL is specified as a string (e.g. `advance: "/other-path"`), the browser history will advance, and the URL shown in the URL bar will be replaced with the value specified. |
 | `overlay` | `true` | Whether to show a backdrop overlay behind the drawer. |
 | `close_button` | `true` | Shows or hide a close button (X). |
 | `header` | `true` | Whether to display a header. |

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../javascript": {
       "name": "ultimate_turbo_modal",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "@hotwired/turbo-rails": "^8.0.0",

--- a/lib/generators/ultimate_turbo_modal/templates/ultimate_turbo_modal.rb
+++ b/lib/generators/ultimate_turbo_modal/templates/ultimate_turbo_modal.rb
@@ -16,6 +16,7 @@ UltimateTurboModal.configure do |config|
 
   # config.drawer do |d|
   #   d.position = :right
+  #   d.advance = false
   #   d.close_button = true
   #   d.header = true
   #   d.header_divider = false

--- a/lib/ultimate_turbo_modal/base.rb
+++ b/lib/ultimate_turbo_modal/base.rb
@@ -7,7 +7,7 @@ class UltimateTurboModal::Base < Phlex::HTML
   VALID_DRAWER_SIZES = %i[xs sm md lg xl 2xl full].freeze
   VALID_DRAWER_POSITIONS = %i[right left].freeze
 
-  # @param advance [Boolean, String] Whether to update the browser history when opening and closing the modal (modal-only, ignored for drawers)
+  # @param advance [Boolean, String] Whether to update the browser history when opening and closing the modal or drawer
   # @param allowed_click_outside_selector [String] CSS selectors for elements that are allowed to be clicked outside of the modal without dismissing the modal
   # @param close_button [Boolean] Whether to show a close button
   # @param close_button_data_action [String] `data-action` attribute for the close button
@@ -45,18 +45,15 @@ class UltimateTurboModal::Base < Phlex::HTML
 
     if drawer?
       cfg = UltimateTurboModal.configuration.drawer_config
-      @advance = false
-      @advance_url = nil
-      @close_button = close_button.nil? ? cfg.close_button : close_button
       @drawer_size = self.class.validate_drawer_size!(size || cfg.size)
     else
       cfg = UltimateTurboModal.configuration.modal_config
-      adv = advance.nil? ? cfg.advance : advance
-      @advance = !!adv
-      @advance_url = (adv.present? && adv.is_a?(String)) ? adv : nil
-      @close_button = close_button.nil? ? cfg.close_button : close_button
       @drawer_size = nil
     end
+    adv = advance.nil? ? cfg.advance : advance
+    @advance = !!adv
+    @advance_url = (adv.present? && adv.is_a?(String)) ? adv : nil
+    @close_button = close_button.nil? ? cfg.close_button : close_button
     @footer_divider = footer_divider.nil? ? cfg.footer_divider : footer_divider
     @header = header.nil? ? cfg.header : header
     @header_divider = header_divider.nil? ? cfg.header_divider : header_divider

--- a/lib/ultimate_turbo_modal/configuration.rb
+++ b/lib/ultimate_turbo_modal/configuration.rb
@@ -41,7 +41,7 @@ module UltimateTurboModal
 
     # Shared base for modal and drawer configuration
     class BaseConfig
-      attr_reader :close_button, :header, :header_divider, :footer_divider, :padding, :overlay
+      attr_reader :advance, :close_button, :header, :header_divider, :footer_divider, :padding, :overlay
 
       def self.boolean_option(name)
         define_method(:"#{name}=") do |value|
@@ -56,6 +56,14 @@ module UltimateTurboModal
       boolean_option :footer_divider
       boolean_option :overlay
 
+      def advance=(value)
+        if [true, false].include?(value) || value.is_a?(String)
+          @advance = value
+        else
+          raise ArgumentError, "Value must be a boolean or a String."
+        end
+      end
+
       def padding=(padding)
         if [true, false].include?(padding) || padding.is_a?(String)
           @padding = padding
@@ -66,8 +74,6 @@ module UltimateTurboModal
     end
 
     class ModalConfig < BaseConfig
-      attr_reader :advance
-
       def initialize
         @advance = false
         @close_button = true
@@ -77,12 +83,10 @@ module UltimateTurboModal
         @padding = true
         @overlay = true
       end
-
-      boolean_option :advance
     end
 
     class DrawerConfig < BaseConfig
-      attr_reader :size, :position, :advance
+      attr_reader :size, :position
 
       def initialize
         @advance = false
@@ -95,8 +99,6 @@ module UltimateTurboModal
         @size = :md
         @position = :right
       end
-
-      boolean_option :advance
 
       def size=(value)
         @size = UltimateTurboModal::Base.validate_drawer_size!(value)

--- a/lib/ultimate_turbo_modal/configuration.rb
+++ b/lib/ultimate_turbo_modal/configuration.rb
@@ -82,9 +82,10 @@ module UltimateTurboModal
     end
 
     class DrawerConfig < BaseConfig
-      attr_reader :size, :position
+      attr_reader :size, :position, :advance
 
       def initialize
+        @advance = false
         @close_button = true
         @header = true
         @header_divider = false
@@ -94,6 +95,8 @@ module UltimateTurboModal
         @size = :md
         @position = :right
       end
+
+      boolean_option :advance
 
       def size=(value)
         @size = UltimateTurboModal::Base.validate_drawer_size!(value)


### PR DESCRIPTION
## Summary
- Drawers now accept the `advance` option (Boolean or String), default `false`, matching how modals already work.
- Configurable globally via `config.drawer { |d| d.advance = ... }` or per-instance via `drawer(advance: ...)`.
- Stacked modals opened from inside a drawer still force `advance: false`, so the drawer's URL stays in the bar.

## Test plan
- [ ] Open a drawer with `advance: true` and verify the URL bar updates and Back closes it
- [ ] Open a drawer with `advance: "/custom/path"` and verify the custom URL is pushed
- [ ] Open a stacked modal from a drawer with `advance: true` on the inner modal and verify history is NOT pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)