### PR TITLE
Make the modal controller work when rendered without a <turbo-frame>

### DIFF
--- a/javascript/modal_controller.js
+++ b/javascript/modal_controller.js
@@ -116,6 +116,15 @@ export default class extends Controller {
     }
   }
 
+  // The element that carries UTMR's lifecycle events (modal:closing,
+  // modal:closed). Normally the enclosing <turbo-frame>, but a modal can be
+  // rendered without one (for example cloned from a <template>), so fall back
+  // to the controller's own element. That keeps the close flow working and
+  // lets listeners such as hideModalWithPromise resolve in both cases.
+  #eventTarget() {
+    return this.turboFrame || this.element;
+  }
+
   // Animate the close transition, then clean up.
   // history.back() is deferred to after the animation so Turbo doesn't
   // replace the page before the animation finishes.
@@ -126,7 +135,7 @@ export default class extends Controller {
     this.hidingModal = true;
 
     let event = new Event('modal:closing', { cancelable: true });
-    this.turboFrame.dispatchEvent(event);
+    this.#eventTarget().dispatchEvent(event);
     if (event.defaultPrevented) {
       this.hidingModal = false;
       return false
@@ -138,7 +147,7 @@ export default class extends Controller {
 
   hideModalWithPromise(options = {}) {
     return new Promise((resolve) => {
-      const frame = this.turboFrame;
+      const frame = this.#eventTarget();
       const handler = () => {
         frame.removeEventListener('modal:closed', handler);
         resolve();
@@ -276,7 +285,7 @@ export default class extends Controller {
       delete dialog.dataset.utmrSkipHistoryBack;
       this.#releaseScrollbarCompensation();
       this.#resetHistoryAdvanced();
-      try { frame.dispatchEvent(new Event('modal:closed', { cancelable: false })); } catch (_) {}
+      try { this.#eventTarget().dispatchEvent(new Event('modal:closed', { cancelable: false })); } catch (_) {}
 
       // Go back in history AFTER the dialog is removed and animation is done.
       // This triggers Turbo's popstate navigation to restore the previous page.
@@ -305,7 +314,7 @@ export default class extends Controller {
     try { frame.removeAttribute("src"); } catch (_) {}
     try { dialog.remove(); } catch (_) {}
     this.#releaseScrollbarCompensation();
-    try { frame.dispatchEvent(new Event('modal:closed', { cancelable: false })); } catch (_) {}
+    try { this.#eventTarget().dispatchEvent(new Event('modal:closed', { cancelable: false })); } catch (_) {}
   }
 
   // Remove any stale dialogs of the same kind left over from a previous failed


### PR DESCRIPTION
## Summary

`modal_controller.js` assumes the dialog is always inside a `<turbo-frame>`. It looks the frame up once in `connect()` and dispatches its `modal:closing` / `modal:closed` events on it. When a dialog is rendered outside a frame, `this.turboFrame` is `null` and `hideModal()` throws on the first close. By that point `hidingModal` is already `true`, so the guard at the top of `hideModal()` ignores every later call, and the close button, Escape, and outside-click all stop responding.

## Why render a modal without a frame

Some modals don't need a server round-trip: a help dialog, a confirmation, an on-page filter drawer. The content is already on the page, so there's no route to fetch. A common way to do this is to keep the markup in a `<template>` and clone it in on demand, reusing UTMR's chrome and this controller for the open/close behavior. Without a `<turbo-frame>` around it, the close flow currently breaks on the first click.

## The change

Add a private `#eventTarget()` that returns the `<turbo-frame>` when there is one and the controller's own element otherwise, and dispatch and listen for the lifecycle events on that target. Clearing the frame's `src` stays frame-only, since a frameless dialog has nothing to clear.

```js
#eventTarget() {
  return this.turboFrame || this.element;
}
```

Framed modals behave exactly as before: when a frame exists, `#eventTarget()` returns it, so the events fire on the same element they always did. The diff is 13 lines.

## Reproducing

Render UTMR's dialog markup somewhere that isn't inside `<turbo-frame id="modal">` and click the close button. On `main` the first click throws and the dialog won't close; with this change it closes normally.

## Testing

There's no JS test suite in the repo, so I verified this by reading through the close paths and by running the change in a companion library that renders these dialogs from a `<template>` outside a frame. Glad to add a regression test or a demo-app example if you'd like one, and to adjust the helper's name or placement.

Opening as a draft for your read on the approach.